### PR TITLE
fixing display of multiple authors

### DIFF
--- a/pkg/index.scm
+++ b/pkg/index.scm
@@ -51,7 +51,7 @@
       (td (@ (class . "detail")) ,desc)
       (td ,@(map
              (lambda (auth email)
-               `(a (@ (href . ,(string-append "mailto:" (or auth-email ""))))
+               `(a (@ (href . ,(string-append "mailto:" (or email ""))))
                    ,auth))
              (if (pair? auth) auth (list auth))
              (append (if (pair? auth-email) auth-email (list auth-email))


### PR DESCRIPTION
The original fix [1] still uses auth-email (a list) instead of email (a
string), which leads to errors and hides some
packages (e.g. (generators) by Shiro, John and Thomas).

This is only reproducible locally, not on snow-fort.org. I suppose
there's already a fix there.

[1] 2583f1e (fixing display of multiple authors, 2015-07-01)