### PR TITLE
Only display doc link if doc property is set

### DIFF
--- a/pkg/index.scm
+++ b/pkg/index.scm
@@ -24,11 +24,13 @@
          (dir (package-dir email pkg))
          (docs (assoc-get pkg 'manual))
          (doc (if (pair? docs) (car docs) docs))
-         (doc-url (if (and (string? doc)
-                           (or (string-prefix? doc "http:")
-                               (string-prefix? doc "https:")))
-                      doc
-                      (make-path (static-url cfg dir) "index.html")))
+         (doc-url (cond
+                   ((not (string? doc)) #f)
+                   ((or (string-prefix? doc "http:")
+                        (string-prefix? doc "https:"))
+                    doc)
+                   (else
+                    (make-path (static-url cfg dir) "index.html"))))
          (auth (package-author repo pkg))
          (maint (package-maintainer repo pkg))
          (auth-email (if (and maint (not (equal? auth maint)))
@@ -65,7 +67,7 @@
                   "(" (a (@ (href . ,(string-append "mailto:" (or email ""))))
                          ,maint) ")")
                 '()))
-      (td (a (@ (href . ,doc-url)) "[html]")))))
+      (td (a (@ (href . ,(or doc-url ""))) ,(if doc-url "[html]" ""))))))
 
 (define repo->sxml-table
   (memoize-file-loader


### PR DESCRIPTION
I've experimented a bit with snow-fort and found that a few dozen packages have broken documentation links. It appears that only packages that have the documentation property set (be it to a relative or absolute URL) have a corresponding index.html sitting next to the tarball in the webroot. I've done some testing to verify that there's an equal number of packages missing that property and packages missing that index.html file and adjusted the logic accordingly to hide the documentation link for them. This should be a subtle indicator that there's some improvement left to do. Please let me know if I've overlooked something here.