### PR TITLE
Style table headers to show sort icons by default

### DIFF
--- a/s/snow.css
+++ b/s/snow.css
@@ -111,6 +111,13 @@ td,th {
   padding-bottom: 0.5em;
   white-space: nowrap;
 }
+table.sortable th::after {
+  content: '\00a0\25b4\25be';
+}
+table.sortable th.sorttable_sorted::after,
+table.sortable th.sorttable_sorted_reverse::after {
+  content: initial;
+}
 td.detail {
   white-space: normal;
 }


### PR DESCRIPTION
Screenshot:

![20210327_230342](https://user-images.githubusercontent.com/3588994/112736144-badaf700-8f50-11eb-908c-8c4fb9c10ef1.png)
