### PR TITLE
WIP: Document currently used routes

### DIFF
--- a/config.scm
+++ b/config.scm
@@ -1,25 +1,24 @@
 
-;; / - welcome, links to pkg list, docs, and fun stuff
+;; / - welcome, links to pkg list and docs
 ;;   /pkg - packages, default to browser
 ;;     /pkg/repo - download the repository
-;;     /pkg/get - download a package
 ;;     /pkg/put - upload a package
 ;;     /pkg/reg - register a key
 ;;   /doc - documentation
-;;     /doc/snow - snow docs
-;;   /fun - fun stuff
-;;     /fun/repl - in-browser repl
-;;     /fun/sorting-hat - the scheme sorting hat
+;;     /doc/install - how to install packages
+;;     /doc/author - how to create and publish packages
+;;     /doc/spec - snow specification
+;;     /doc/usage - CLI usage
+;;   /faq - frequently asked questions
+;;   /link - scheme resources
 ;;   /s - static files, empty index
 ;;     /s/snow.css
 ;;     /s/favicon.ico
 ;;     /s/repo.scm
 ;;     /s/<domain>/<local>/registration-pending - file with verify key (rand)
 ;;     /s/<domain>/<local>/pub-key - also in /s/repo
-;;     /s/<domain>/<local>/files/<petname>/<modname>/<version>/<modname-1.0.tgz>
-;;     /s/<domain>/<local>/doc/<petname>/<modname>/<version>/<modname.html>
-;;     /s/<domain>/<local>/view/<petname>/<modname>/<version>/<modname.sld>
-;;     /s/<domain>/<local>/view/<petname>/<modname>/...
+;;     /s/<domain>/<local>/<modname>/<version>/<modname-<version>.tgz>
+;;     /s/<domain>/<local>/<modname>/<version>/index.html
 
 ((path
   ((or (: "/s/" (* any))


### PR DESCRIPTION
I went over the repository and tried figuring out what routes do and don't exist. I'm not 100% sure about the static stuff, especially the `<petname>` convention. It doesn't seem to be used at all. The removed static routes seem to be about future ideas, such as generating static files (like package sources) upon upload. Maybe these should be put into a TODO.org instead.

Another thing I've noticed is that not all static files are available. I get a 403 for http://snow-fort.org/s/gmail.com/alexshinn/pub-key (it's public information in http://snow-fort.org/pkg/repo). This response is appropriate for the pending files, so it should be a matter of reviewing the nginx configuration.