### PR TITLE
Removed quote from license value in example package declaration

### DIFF
--- a/doc/spec/index.scm
+++ b/doc/spec/index.scm
@@ -57,7 +57,7 @@
   ;;  * artistic
   ;;  * apache
   ;;  * public-domain
-  (license 'bsd)
+  (license bsd)
   ;; Current version string.
   (version \"1.2.3\")
   ;; Program containing tests to run before installing this package.


### PR DESCRIPTION
Looking at actual repository, license values aren't quoted